### PR TITLE
Due to the recent upgrade to PHP 8.1 PHP-PEAR now points to PHP-8.1

### DIFF
--- a/8.0/cli/Dockerfile
+++ b/8.0/cli/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update; \
         php8.0-xml \
         php8.0-zip
 
+RUN update-alternatives --set php /usr/bin/php8.0
+
 RUN apt-get autoremove -y -q && \
     apt-get autoclean -y -q && \
     rm -rf /var/lib/apt/lists/*

--- a/dockerhub.sh
+++ b/dockerhub.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Validate the container passes our tests
-./test.sh
-
 # You need to provide your own creds because #security
 docker login
 
@@ -17,4 +14,9 @@ do
 
   docker build --no-cache -t sykescottages/php:${VERSION}-fpm $VERSION/fpm
   docker push sykescottages/php:${VERSION}-fpm
+
+  docker rmi sykescottages/php:${VERSION}-cli
+  docker rmi sykescottages/php:${VERSION}-fpm
 done
+
+docker rmi sykescottages/php:base


### PR DESCRIPTION
This corrects the binary path to revert back to PHP 8.0