### PR TITLE
Parses available versions from dir structure

### DIFF
--- a/dockerhub.sh
+++ b/dockerhub.sh
@@ -3,7 +3,7 @@
 # You need to provide your own creds because #security
 docker login >> /dev/null 2>&1
 
-BASE_VERSIONS=($(find . -type d -name '[0-9]-base' | sort | sed 's/\.\///'))
+BASE_VERSIONS=($(find . -type d -regex '.*/[0-9]\{1,2\}-base' | sort | sed 's/\.\///'))
 for VERSION in "${BASE_VERSIONS[@]}"
 do
   ./build-base.sh $VERSION >> /dev/null 2>&1 &
@@ -11,7 +11,7 @@ done
 
 wait
 
-VERSIONS=($(find . -type d -name '[0-9]\.[0-9]' | sort))
+VERSIONS=($(find . -type d -regex '.*/[0-9]\{1,2\}\.[0-9]' | sort))
 for VERSION in "${VERSIONS[@]}"
 do
   ./build.sh $VERSION >> /dev/null 2>&1 &

--- a/dockerhub.sh
+++ b/dockerhub.sh
@@ -3,15 +3,15 @@
 # You need to provide your own creds because #security
 docker login >> /dev/null 2>&1
 
-VERSIONS=( "5-base" "7-base" "8-base" )
-for VERSION in "${VERSIONS[@]}"
+BASE_VERSIONS=($(find . -type d -name '[0-9]-base' | sort | sed 's/\.\///'))
+for VERSION in "${BASE_VERSIONS[@]}"
 do
   ./build-base.sh $VERSION >> /dev/null 2>&1 &
 done
 
 wait
 
-VERSIONS=( "5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" )
+VERSIONS=($(find . -type d -name '[0-9]\.[0-9]' | sort))
 for VERSION in "${VERSIONS[@]}"
 do
   ./build.sh $VERSION >> /dev/null 2>&1 &
@@ -19,8 +19,7 @@ done
 
 wait
 
-VERSIONS=( "5-base" "7-base" "8-base" )
-for VERSION in "${VERSIONS[@]}"
+for VERSION in "${BASE_VERSIONS[@]}"
 do
   docker rmi sykescottages/php:${VERSION} >> /dev/null 2>&1 &
 done

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-VERSIONS=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1")
+VERSIONS=($(find . -type d -name '[0-9]\.[0-9]' | sort))
+
 for VERSION in "${VERSIONS[@]}"; do
   docker-compose -f $VERSION/cli/docker-compose.test.yml build --no-cache &&
     docker-compose -f $VERSION/cli/docker-compose.test.yml run --rm sut

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSIONS=($(find . -type d -name '[0-9]\.[0-9]' | sort))
+VERSIONS=($(find . -type d -regex '.*/[0-9]\{1,2,\}\.[0-9]' | sort))
 
 for VERSION in "${VERSIONS[@]}"; do
   docker-compose -f $VERSION/cli/docker-compose.test.yml build --no-cache &&

--- a/versions.sh
+++ b/versions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-VERSIONS=( "5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" )
+VERSIONS=($(find . -type d -name '[0-9]\.[0-9]' | sort))
+
 for VERSION in "${VERSIONS[@]}"
 do
   docker run sykescottages/php:${VERSION}-cli -v|grep -E "^PHP "

--- a/versions.sh
+++ b/versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSIONS=($(find . -type d -name '[0-9]\.[0-9]' | sort))
+VERSIONS=($(find . -type d -regex '.*/[0-9]\{1,2\}\.[0-9]' | sort))
 
 for VERSION in "${VERSIONS[@]}"
 do


### PR DESCRIPTION
I noticed that `test.sh` did not cover v8.2 so have replaced hardcoded version numbers across all scripts with commands which will instead, parse the root dir structure and build an array of available versions.